### PR TITLE
fix: `user/delete` API bug fix

### DIFF
--- a/src/repositories/users.js
+++ b/src/repositories/users.js
@@ -906,6 +906,10 @@ const registerUserFromWhatsApp = async (payload) => {
   }
 };
 
+const removeUser = async (payload) => {
+  return await baseRepo.remove(table, payload, "hard");
+};
+
 module.exports = {
   getAllowedTypes,
   getAllowedVerificationMethods,
@@ -934,4 +938,5 @@ module.exports = {
   verifyAttributeForResetPasswordWithLink,
   verifyOldPasswordAndResetPassword,
   registerUserFromWhatsApp,
+  removeUser,
 };


### PR DESCRIPTION
### Summary

- `TypeError: usersRepo.removeUser is not a function` Error is replicating in the `user/delete` API
- Resolved that error by adding `removeUser` method in `users` repo - `src/repositories/users.js`