### PR TITLE
debug: soft delete of `attributes` and `users`

### DIFF
--- a/src/repositories/attributes.js
+++ b/src/repositories/attributes.js
@@ -37,7 +37,7 @@ const getAttributesForUUID = async (uuid) => {
 
 const deleteAccount = async (where = {}) => {
   try {
-    return await baseRepo.remove(table, where, 'hard');
+    return await baseRepo.remove(table, where, 'soft');
   } catch (error) {
     throw error;
   }

--- a/src/repositories/users.js
+++ b/src/repositories/users.js
@@ -907,7 +907,7 @@ const registerUserFromWhatsApp = async (payload) => {
 };
 
 const removeUser = async (payload) => {
-  return await baseRepo.remove(table, payload, "hard");
+  return await baseRepo.remove(table, payload, "soft");
 };
 
 module.exports = {


### PR DESCRIPTION
### Todos


- [x] Enable 'soft' delete for the `users` table as we call `/user/delete` API
- [x] Enable 'soft' delete for the `attributes` table as we call `/user/delete` API
- [x] Test 'soft' delete for the `users` table as we call `/user/delete` API
- [x] Test 'soft' delete for the `attributes` table as we call `/user/delete` API
