### PR TITLE
as per our new requirements we have to enable deleteAccount staging

### DIFF
--- a/src/stories/Users/CanDeleteAccount/story.js
+++ b/src/stories/Users/CanDeleteAccount/story.js
@@ -34,8 +34,8 @@ const authorize = async ({ prepareResult }) => {
 const handle = async ({ prepareResult, authorizeResult }) => {
   try {
     if (
-      process.env.DISABLE_DELETE_ACCOUNT &&
-      process.env.DISABLE_DELETE_ACCOUNT.toString() === "true"
+      process.env.ENVIRONMENT &&
+      process.env.ENVIRONMENT.toUpperCase() === "PRODUCTION"
     ) {
       return;
     }


### PR DESCRIPTION
**Delete Account and Investor**

Users will be required to register using both email and mobile.
**Delete Investor Only**

Users will need to log in again and can continue from the Enter PAN step.

We need to dynamically enable and disable the delete account API based on the environment to enable the delete account feature in the staging environment.

**Impact:**

In the app where this change is implemented, the delete account API will be able to delete records in the staging environment.
The environment variable ENVIRONMENT needs to be added to the infrastructure.
Changes:

 We have implemented registration requirements for email and mobile for account and investor deletion.
 Added logic to conditionally enable the delete account API based on the environment.
 Updated infrastructure to include the ENVIRONMENT variable.
Please review the changes and let me know if any adjustments are needed.
